### PR TITLE
Fix: data and software resources requires to be URL not ObjectID

### DIFF
--- a/src/models/ServiceOffering/ServiceOffering.model.ts
+++ b/src/models/ServiceOffering/ServiceOffering.model.ts
@@ -44,10 +44,8 @@ export const serviceOfferingSchema = new Schema<
     location: { type: String, default: "" },
     description: { type: String, default: "" },
     keywords: [String],
-    dataResources: [{ type: Schema.Types.ObjectId, ref: "DataResource" }],
-    softwareResources: [
-      { type: Schema.Types.ObjectId, ref: "SoftwareResource" },
-    ],
+    dataResources: [{ type: String, ref: "DataResource" }],
+    softwareResources: [{ type: String, ref: "SoftwareResource" }],
 
     // Gaia-x federation
     compliantServiceOfferingVC: { type: String, default: "" },


### PR DESCRIPTION
To handle [that line](https://github.com/Prometheus-X-association/dataspace-connector/blob/main/src/services/public/v1/provider.public.service.ts#L52), ObjectID is not reachable.