### PR TITLE
Service offering in public catalog missing selfdescription on resources

### DIFF
--- a/src/controllers/public/v1/catalog.public.controller.ts
+++ b/src/controllers/public/v1/catalog.public.controller.ts
@@ -265,6 +265,13 @@ export const getServiceOfferingSD = async (
       req.params.id
     ).lean();
 
+    serviceOffering["dataResources"] = serviceOffering["dataResources"].map(
+      (dr) => `${process.env.API_URL}/catalog/dataresources/${dr}`
+    );
+    serviceOffering["softwareResources"] = serviceOffering[
+      "softwareResources"
+    ].map((sr) => `${process.env.API_URL}/catalog/softwareresources/${sr}`);
+
     const result = {
       "@context": CONFIG.apiUrl + "/serviceoffering",
       "@type": "ServiceOffering",


### PR DESCRIPTION
## feat
- added for the public service offering routes the dataresources and softwareresources self description instead of the id